### PR TITLE
Allow cross-namespace restore of CSI snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ BIN ?= velero-plugin-for-csi
 
 BUILD_IMAGE ?= golang:1.13-stretch
 
-REGISTRY ?= velero
+REGISTRY ?= catalogicsoftware
 IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-csi
-TAG ?= dev
+TAG ?= v0.1.2.2
 
 IMAGE ?= $(IMAGE_NAME):$(TAG)
 

--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -97,6 +97,12 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 
 	resetPVCAnnotations(&pvc, []string{velerov1api.BackupNameLabel, util.VolumeSnapshotLabel})
 
+	// If cross-namespace restore is configured, change the namespace
+	// for PVC object to be restored
+	if val, ok := input.Restore.Spec.NamespaceMapping[pvc.GetNamespace()]; ok {
+		pvc.SetNamespace(val)
+	}
+
 	volumeSnapshotName, ok := pvc.Annotations[util.VolumeSnapshotLabel]
 	if !ok {
 		p.Log.Infof("Skipping PVCRestoreItemAction for PVC %s/%s, PVC does not have a CSI volumesnapshot.", pvc.Namespace, pvc.Name)


### PR DESCRIPTION
- Check for namespace mapping information.
- If there is a map, replace VolumeSnapshots namespace to the target namespace

Fixes KUBEDR-364

Fixes Issues these similar issues from Velero:
1. https://github.com/vmware-tanzu/velero/issues/2143
2. https://github.com/vmware-tanzu/velero-plugin-for-csi/issues/75