### PR TITLE
Skip velero snapshot for nfs-csi driver

### DIFF
--- a/internal/backup/pvc_action.go
+++ b/internal/backup/pvc_action.go
@@ -107,6 +107,12 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *velerov
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting storage class")
 	}
+
+	if storageClass.Provisioner == "nfs.csi.k8s.io" {
+		p.Log.Infof("Skipping PVC %s/%s, associated PV %s with provisioner %s is not supported", pvc.Namespace, pvc.Name, pv.Name, "nfs.csi.k8s.io")
+		return item, nil, nil
+	}
+
 	p.Log.Debugf("Fetching volumesnapshot class for %s", storageClass.Provisioner)
 	snapshotClass, err := util.GetVolumeSnapshotClassForStorageClass(storageClass.Provisioner, snapshotClient.SnapshotV1())
 	if err != nil {


### PR DESCRIPTION
FIXES KUBEDR-3626

Verified by creating NFS PVCs and running backup restore operations:

```
cm@catalogic:~/catalogic/velero-plugin-for-csi$ kubectl get pvc
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-pv-claim   Bound    pvc-15354a6e-1868-46bd-be4b-4209c7f0a445   10Gi       RWO            nfs-csi        45m
wp-pv-claim      Bound    pvc-7e68419b-3083-46eb-bb23-4ad184944123   10Gi       RWO            nfs-csi        45m
```

Log snippet from Velero plugin:

```
{"backup":"cloudcasa-io/6346db4bbdf9dd454a698dcc","cmd":"/plugins/velero-plugin-for-csi","level":"info","logSource":"/go/src/velero-plugin-for-csi/internal/backup/pvc_action.go:105","msg":"Fetching storage class for PV nfs-csi","pluginName":"velero-plugin-for-csi","time":"2022-10-12T15:21:08Z"}
{"backup":"cloudcasa-io/6346db4bbdf9dd454a698dcc","cmd":"/plugins/velero-plugin-for-csi","level":"info","logSource":"/go/src/velero-plugin-for-csi/internal/backup/pvc_action.go:112","msg":"Skipping PVC default/wp-pv-claim, associated PV pvc-7e68419b-3083-46eb-bb23-4ad184944123 with provisioner nfs.csi.k8s.io is not supported","pluginName":"velero-plugin-for-csi","time":"2022-10-12T15:21:08Z"}

{"backup":"cloudcasa-io/6346db4bbdf9dd454a698dcc","cmd":"/plugins/velero-plugin-for-csi","level":"info","logSource":"/go/src/velero-plugin-for-csi/internal/backup/pvc_action.go:61","msg":"Starting PVCBackupItemAction","pluginName":"velero-plugin-for-csi","time":"2022-10-12T15:21:09Z"}
{"backup":"cloudcasa-io/6346db4bbdf9dd454a698dcc","cmd":"/plugins/velero-plugin-for-csi","level":"info","logSource":"/go/src/velero-plugin-for-csi/internal/backup/pvc_action.go:105","msg":"Fetching storage class for PV nfs-csi","pluginName":"velero-plugin-for-csi","time":"2022-10-12T15:21:09Z"}
{"backup":"cloudcasa-io/6346db4bbdf9dd454a698dcc","cmd":"/plugins/velero-plugin-for-csi","level":"info","logSource":"/go/src/velero-plugin-for-csi/internal/backup/pvc_action.go:112","msg":"Skipping PVC default/mysql-pv-claim, associated PV pvc-15354a6e-1868-46bd-be4b-4209c7f0a445 with provisioner nfs.csi.k8s.io is not supported","pluginName":"velero-plugin-for-csi","time":"2022-10-12T15:21:09Z"}
```