### PR TITLE
KUBEDR-4155: Remove pvc.Spec.DataSourceRef for restore from copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_IMAGE ?= golang:1.17.13-buster
 
 REGISTRY ?= catalogicsoftware
 IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-csi
-TAG ?= v0.3.1.6
+TAG ?= v0.3.1.7
 
 IMAGE ?= $(IMAGE_NAME):$(TAG)
 

--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -135,6 +135,9 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 		if pvc.Spec.DataSource != nil && pvc.Spec.DataSource.Kind == "VolumeSnapshot" {
 			pvc.Spec.DataSource = nil
 		}
+		if pvc.Spec.DataSourceRef != nil && pvc.Spec.DataSourceRef.Kind == "VolumeSnapshot" {
+			pvc.Spec.DataSourceRef = nil
+		}
 		pvcMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
 		if err != nil {
 			return nil, errors.WithStack(err)


### PR DESCRIPTION
This code change is all we need to fix KUBEDR-4155 as volumesnapshots and volumesnapshotcontents is in excludedResources for restore from copy.
DataSource was already removed from the PVC but since DataSourceRef was still there DataSource was getting added back.
Once both DataSource and DataSourceRef are removed they don't get added back and PVC gets bound and restore works.

For more details see:
https://catalogicsoftware.atlassian.net/browse/KUBEDR-4155?focusedCommentId=507165

Failed automated tests:
```
src/test_user_objectstores_s3.py::TestUserObjectstoreSetting::test_backup_with_user_objectstore_for_org FAILED                                                                         [ 94%]
src/test_user_objectstores_s3.py::TestUserObjectstoreSetting::test_backup_with_user_objectstore_for_cluster FAILED                                                                     [ 96%]
```
